### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/buildtimetrend/__init__.py
+++ b/buildtimetrend/__init__.py
@@ -31,7 +31,7 @@ import logging
 NAME = "buildtimetrend"
 VERSION = "0.4.dev10"
 SCHEMA_VERSION = "3"
-USER_AGENT = "%s/%s" % (NAME, VERSION)
+USER_AGENT = "{0!s}/{1!s}".format(NAME, VERSION)
 
 
 def get_logger():
@@ -50,11 +50,11 @@ def set_loglevel(loglevel):
     specify --log=DEBUG or --log=debug
     """
     if loglevel is None or type(loglevel) is not str:
-        raise TypeError("param %s should be a string" % 'loglevel')
+        raise TypeError("param {0!s} should be a string".format('loglevel'))
 
     numeric_level = getattr(logging, loglevel.upper(), None)
     if not isinstance(numeric_level, int):
-        raise ValueError('Invalid log level: %s' % loglevel)
+        raise ValueError('Invalid log level: {0!s}'.format(loglevel))
 
     # create handler
     log_handler = logging.StreamHandler()

--- a/buildtimetrend/stages.py
+++ b/buildtimetrend/stages.py
@@ -151,7 +151,7 @@ class Stages(object):
         param stage Stage instance
         """
         if not isinstance(stage, Stage):
-            raise TypeError("param %s should be a Stage instance" % stage)
+            raise TypeError("param {0!s} should be a Stage instance".format(stage))
 
         # add stage
         self.stages.append(stage.to_dict())

--- a/buildtimetrend/stages.py
+++ b/buildtimetrend/stages.py
@@ -151,7 +151,9 @@ class Stages(object):
         param stage Stage instance
         """
         if not isinstance(stage, Stage):
-            raise TypeError("param {0!s} should be a Stage instance".format(stage))
+            raise TypeError(
+                "param {0!s} should be a Stage instance".format(stage)
+            )
 
         # add stage
         self.stages.append(stage.to_dict())

--- a/buildtimetrend/test/keenio_tests.py
+++ b/buildtimetrend/test/keenio_tests.py
@@ -583,7 +583,9 @@ class TestKeen(unittest.TestCase):
             }]
         })
 
-        self.assertEqual(234, keenio.get_total_build_jobs("test/repo2", "year"))
+        self.assertEqual(
+            234, keenio.get_total_build_jobs("test/repo2", "year")
+        )
 
         # test parameters passed to keen.average
         args, kwargs = keen_count_func.call_args
@@ -878,7 +880,9 @@ class TestKeen(unittest.TestCase):
     )
     def test_pct_passed_build_jobs(self, passed_func, total_func):
         """Test keenio.get_pct_passed_build_jobs()"""
-        self.assertEqual(75, keenio.get_pct_passed_build_jobs("test/repo", "week"))
+        self.assertEqual(
+            75, keenio.get_pct_passed_build_jobs("test/repo", "week")
+        )
 
         # function was last called with argument "test/repo"
         args, kwargs = total_func.call_args
@@ -890,18 +894,28 @@ class TestKeen(unittest.TestCase):
         self.assertDictEqual(kwargs, {})
 
         total_func.return_value = 150
-        self.assertEqual(50, keenio.get_pct_passed_build_jobs("test/repo", "week"))
+        self.assertEqual(
+            50, keenio.get_pct_passed_build_jobs("test/repo", "week")
+        )
 
         total_func.return_value = 0
-        self.assertEqual(-1, keenio.get_pct_passed_build_jobs("test/repo", "week"))
+        self.assertEqual(
+            -1, keenio.get_pct_passed_build_jobs("test/repo", "week")
+        )
         total_func.return_value = -1
-        self.assertEqual(-1, keenio.get_pct_passed_build_jobs("test/repo", "week"))
+        self.assertEqual(
+            -1, keenio.get_pct_passed_build_jobs("test/repo", "week")
+        )
 
         total_func.return_value = 100
         passed_func.return_value = 0
-        self.assertEqual(0, keenio.get_pct_passed_build_jobs("test/repo", "week"))
+        self.assertEqual(
+            0, keenio.get_pct_passed_build_jobs("test/repo", "week")
+        )
         passed_func.return_value = -1
-        self.assertEqual(-1, keenio.get_pct_passed_build_jobs("test/repo", "week"))
+        self.assertEqual(
+            -1, keenio.get_pct_passed_build_jobs("test/repo", "week")
+        )
 
     def test_get_days_since_fail(self):
         """Test keenio.get_days_since_fail()"""

--- a/buildtimetrend/test/parse_travis_log.py
+++ b/buildtimetrend/test/parse_travis_log.py
@@ -36,5 +36,4 @@ travis_data.parse_job_log_file(LOGFILE)
 print()
 print("Finished stages")
 for stage in travis_data.build.stages.stages:
-    print("Substage %s, duration %ss, command : %s" %
-          (stage["name"], stage["duration"], stage["command"]))
+    print("Substage {0!s}, duration {1!s}s, command : {2!s}".format(stage["name"], stage["duration"], stage["command"]))

--- a/buildtimetrend/test/parse_travis_log.py
+++ b/buildtimetrend/test/parse_travis_log.py
@@ -36,4 +36,6 @@ travis_data.parse_job_log_file(LOGFILE)
 print()
 print("Finished stages")
 for stage in travis_data.build.stages.stages:
-    print("Substage {0!s}, duration {1!s}s, command : {2!s}".format(stage["name"], stage["duration"], stage["command"]))
+    print("Substage {0!s}, duration {1!s}s, command : {2!s}".format(
+        stage["name"], stage["duration"], stage["command"])
+    )

--- a/buildtimetrend/test/settings_test.py
+++ b/buildtimetrend/test/settings_test.py
@@ -274,8 +274,8 @@ class TestSettings(unittest.TestCase):
 
         argv = [
             scriptname,
-            "--ci=%s" % expected_ci,
-            "--repo=%s" % expected_project_name,
+            "--ci={0!s}".format(expected_ci),
+            "--repo={0!s}".format(expected_project_name),
             "argument"
         ]
 
@@ -485,12 +485,12 @@ class TestSettings(unittest.TestCase):
         argv = [
             scriptname,
             "--log=INFO",
-            "--ci=%s" % expected_ci,
-            "--build=%s" % expected_build,
-            "--job=%s" % expected_job,
-            "--branch=%s" % expected_branch,
-            "--repo=%s" % expected_project_name,
-            "--result=%s" % expected_result,
+            "--ci={0!s}".format(expected_ci),
+            "--build={0!s}".format(expected_build),
+            "--job={0!s}".format(expected_job),
+            "--branch={0!s}".format(expected_branch),
+            "--repo={0!s}".format(expected_project_name),
+            "--result={0!s}".format(expected_result),
             "--mode=keen",
             "--mode=native",
             "argument"

--- a/buildtimetrend/tools.py
+++ b/buildtimetrend/tools.py
@@ -59,7 +59,7 @@ def split_timestamp(timestamp):
     """
     if not isinstance(timestamp, Number):
         raise TypeError(
-            "param timestamp should be a number %s" % type(timestamp)
+            "param timestamp should be a number {0!s}".format(type(timestamp))
         )
 
     ts_seconds = int(timestamp)
@@ -101,8 +101,8 @@ def split_datetime(timestamp_datetime):
     - timestamp_datetime : timestamp in datetime class format
     """
     if timestamp_datetime is None or type(timestamp_datetime) is not datetime:
-        raise TypeError("param %s should be a datetime instance" %
-                        'timestamp_datetime')
+        raise TypeError("param {0!s} should be a datetime instance".format(
+                        'timestamp_datetime'))
 
     timestamp_dict = {}
     timestamp_dict["isotimestamp"] = timestamp_datetime.isoformat()
@@ -218,7 +218,7 @@ def check_dict(param_dict, name=None, key_list=None):
         if name is None:
             return False
         else:
-            raise TypeError("param %s should be a dictionary" % name)
+            raise TypeError("param {0!s} should be a dictionary".format(name))
 
     # check if key_list is defined
     if key_list is None:
@@ -266,7 +266,7 @@ def is_list(param_list, name=None):
         if name is None:
             return False
         else:
-            raise TypeError("param %s should be a list" % name)
+            raise TypeError("param {0!s} should be a list".format(name))
 
     return True
 
@@ -287,7 +287,7 @@ def is_string(param, name=None):
         if name is None:
             return False
         else:
-            raise TypeError("param %s should be a string" % name)
+            raise TypeError("param {0!s} should be a string".format(name))
 
     return True
 
@@ -303,7 +303,7 @@ def check_num_string(num_string, name):
     """
     if num_string is None or not isinstance(num_string, (string_types, int)):
         raise TypeError(
-            "param %s should be a numerical string or an integer" % name
+            "param {0!s} should be a numerical string or an integer".format(name)
         )
 
     return int(num_string)
@@ -321,6 +321,6 @@ def get_repo_slug(repo_owner=None, repo_name=None):
     - repo_name : name of the Github repo, fe. `service`
     """
     if repo_owner is not None and repo_name is not None:
-        return "%s/%s" % (str(repo_owner), str(repo_name))
+        return "{0!s}/{1!s}".format(str(repo_owner), str(repo_name))
     else:
         return None

--- a/buildtimetrend/tools.py
+++ b/buildtimetrend/tools.py
@@ -302,9 +302,8 @@ def check_num_string(num_string, name):
     Return integer of numerical string, throws error when it isn't
     """
     if num_string is None or not isinstance(num_string, (string_types, int)):
-        raise TypeError(
-            "param {0!s} should be a numerical string or an integer".format(name)
-        )
+        err_msg = "param {0!s} should be a numerical string or an integer"
+        raise TypeError(err_msg.format(name))
 
     return int(num_string)
 

--- a/buildtimetrend/travis/test/env_var_test.py
+++ b/buildtimetrend/travis/test/env_var_test.py
@@ -257,7 +257,7 @@ class TestTravisEnvVar(unittest.TestCase):
                     'os': expected_os,
                     'language': language['language'],
                     'language_version': expected_lang_version,
-                    'summary': "%s %s %s" % (
+                    'summary': "{0!s} {1!s} {2!s}".format(
                         language['language'],
                         expected_lang_version,
                         expected_os

--- a/buildtimetrend/travis/test/travis_test.py
+++ b/buildtimetrend/travis/test/travis_test.py
@@ -380,15 +380,14 @@ class TestTravis(unittest.TestCase):
         self.assertDictEqual(
             {"repo": expected_project_name},
             process_notification_payload(
-                '{"repository": {"owner_name": "%s", "name": "%s"}}'
-                % (expected_owner, expected_repo)
+                '{{"repository": {{"owner_name": "{0!s}", "name": "{1!s}"}}}}'.format(expected_owner, expected_repo)
             )
         )
 
         # test with string, only containing build info
         self.assertDictEqual(
             {"build": expected_build},
-            process_notification_payload('{"number": "%s"}' % expected_build)
+            process_notification_payload('{{"number": "{0!s}"}}'.format(expected_build))
         )
 
         # test with unicode string

--- a/buildtimetrend/trend.py
+++ b/buildtimetrend/trend.py
@@ -62,7 +62,7 @@ class Trend(object):
             job_id = build_xml.get('job')
 
             if job_id is None and build_id is None:
-                build_name = "#{0:d}".format((index + 1))
+                build_name = "#{0:d}".format(index + 1)
             elif job_id is not None:
                 build_name = job_id
             else:

--- a/buildtimetrend/trend.py
+++ b/buildtimetrend/trend.py
@@ -62,7 +62,7 @@ class Trend(object):
             job_id = build_xml.get('job')
 
             if job_id is None and build_id is None:
-                build_name = "#%d" % (index + 1)
+                build_name = "#{0:d}".format((index + 1))
             elif job_id is not None:
                 build_name = job_id
             else:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:buildtimetrend:python-lib?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:buildtimetrend:python-lib?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)